### PR TITLE
Displaying all attributes in join graph schema area

### DIFF
--- a/src/joinboost/joingraph.py
+++ b/src/joinboost/joingraph.py
@@ -186,8 +186,10 @@ class JoinGraph:
         nodes = []
         links = []
         for table_name in self.relation_schema:
-            nodes.append({"id": table_name, "attributes": self.exe.get_schema(table_name)
-                          + ([self.target_var] if table_name == self.target_relation else [])})
+            attributes = set(self.exe.get_schema(table_name))
+            if table_name == self.target_relation:
+                attributes.add(self.target_var)
+            nodes.append({"id": table_name, "attributes": list(attributes)})
 
         # avoid edge in opposite direction
         seen = set()

--- a/src/joinboost/joingraph.py
+++ b/src/joinboost/joingraph.py
@@ -185,7 +185,7 @@ class JoinGraph:
         nodes = []
         links = []
         for table_name in self.relation_schema:
-            nodes.append({"id": table_name, "attributes": list(self.relation_schema[table_name].keys())})
+            nodes.append({"id": table_name, "attributes": self.exe.get_schema(table_name)})
 
         # avoid edge in opposite direction
         seen = set()


### PR DESCRIPTION
Previously, only features were displayed, but now all attributes will be displayed in the schema area. join keys will be highlighted when edge is selected.
![image](https://user-images.githubusercontent.com/25130825/197930034-49025885-af16-4319-9274-791f3f0bd92d.png)

Possible clean up: if target_var is always subset of attributes, then we can remove 190-191